### PR TITLE
fix: add repository path context to PlatformManager for PR creation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -261,7 +261,7 @@ program
 
           // Phase 5: PR creation (if not --no-pr)
           if (!options.noPr) {
-            const platformManager = new PlatformManager(status.platform, status.remoteURL);
+            const platformManager = new PlatformManager(status.platform, status.remoteURL, gitClient.getWorkingDirectory());
             const capabilities = await platformManager.getCapabilities();
 
             if (capabilities.canCreatePR) {

--- a/src/git/client.ts
+++ b/src/git/client.ts
@@ -1210,4 +1210,11 @@ export class GitClient {
       warnings
     };
   }
+
+  /**
+   * Get the working directory path
+   */
+  getWorkingDirectory(): string {
+    return this.workingDirectory;
+  }
 }

--- a/src/git/platform.ts
+++ b/src/git/platform.ts
@@ -17,10 +17,12 @@ export interface PlatformCapabilities {
 export class PlatformManager {
   private platform: Platform;
   private remoteURL: string;
+  private repositoryPath: string;
 
-  constructor(platform: Platform, remoteURL: string) {
+  constructor(platform: Platform, remoteURL: string, repositoryPath: string) {
     this.platform = platform;
     this.remoteURL = remoteURL;
+    this.repositoryPath = repositoryPath;
   }
 
   /**
@@ -117,7 +119,7 @@ export class PlatformManager {
     }
 
     try {
-      const { stdout } = await execAsync(command);
+      const { stdout } = await execAsync(command, { cwd: this.repositoryPath });
       const prURL = stdout.trim();
       
       // Extract PR number from URL
@@ -162,7 +164,7 @@ export class PlatformManager {
     }
 
     try {
-      const { stdout } = await execAsync(command);
+      const { stdout } = await execAsync(command, { cwd: this.repositoryPath });
       const mrURL = stdout.trim();
       
       // Extract MR number from URL
@@ -218,7 +220,7 @@ export class PlatformManager {
    */
   private async isGitHubCLIAvailable(): Promise<boolean> {
     try {
-      await execAsync('gh --version');
+      await execAsync('gh --version', { cwd: this.repositoryPath });
       // TODO: Check authentication status
       return true;
     } catch {
@@ -231,7 +233,7 @@ export class PlatformManager {
    */
   private async isGitLabCLIAvailable(): Promise<boolean> {
     try {
-      await execAsync('glab --version');
+      await execAsync('glab --version', { cwd: this.repositoryPath });
       // TODO: Check authentication status
       return true;
     } catch {

--- a/src/mcp/toolHandler.ts
+++ b/src/mcp/toolHandler.ts
@@ -439,7 +439,7 @@ export class ToolHandler {
 
         // Phase 6: PR creation with enhanced error handling
         if (pushSuccess && !noPR) {
-          const platformManager = new PlatformManager(updatedStatus.platform, updatedStatus.remoteURL);
+          const platformManager = new PlatformManager(updatedStatus.platform, updatedStatus.remoteURL, repoPath);
           const capabilities = await platformManager.getCapabilities();
 
           if (capabilities.canCreatePR) {
@@ -692,7 +692,7 @@ export class ToolHandler {
         contextFile 
       });
 
-      const platformManager = new PlatformManager(status.platform, status.remoteURL);
+      const platformManager = new PlatformManager(status.platform, status.remoteURL, gitClient.getWorkingDirectory());
       const terminology = platformManager.getPRTerminology();
 
       // Try to use AI for PR generation
@@ -757,7 +757,7 @@ export class ToolHandler {
       }
 
       const status = await gitClient.getStatus();
-      const platformManager = new PlatformManager(status.platform, status.remoteURL);
+      const platformManager = new PlatformManager(status.platform, status.remoteURL, gitClient.getWorkingDirectory());
       const capabilities = await platformManager.getCapabilities();
       const repoInfo = platformManager.parseRepositoryInfo();
 

--- a/tests/git/platform.test.ts
+++ b/tests/git/platform.test.ts
@@ -11,7 +11,7 @@ describe('PlatformManager', () => {
 
   describe('GitHub Platform', () => {
     beforeEach(() => {
-      platformManager = new PlatformManager(Platform.GitHub, 'https://github.com/user/repo.git');
+      platformManager = new PlatformManager(Platform.GitHub, 'https://github.com/user/repo.git', '/test/repo');
       jest.clearAllMocks();
     });
 
@@ -43,7 +43,7 @@ describe('PlatformManager', () => {
 
   describe('GitLab Platform', () => {
     beforeEach(() => {
-      platformManager = new PlatformManager(Platform.GitLab, 'https://gitlab.com/user/repo.git');
+      platformManager = new PlatformManager(Platform.GitLab, 'https://gitlab.com/user/repo.git', '/test/repo');
       jest.clearAllMocks();
     });
 
@@ -64,7 +64,7 @@ describe('PlatformManager', () => {
 
   describe('LocalOnly Platform', () => {
     beforeEach(() => {
-      platformManager = new PlatformManager(Platform.LocalOnly, '');
+      platformManager = new PlatformManager(Platform.LocalOnly, '', '/test/repo');
     });
 
     it('should report no capabilities for local-only repositories', async () => {


### PR DESCRIPTION
Fixes issue where PR creation failed due to missing working directory context in PlatformManager.

## Changes
- Add repositoryPath parameter to PlatformManager constructor
- Update execAsync calls to include cwd option for proper git context
- Add getWorkingDirectory() method to GitClient class
- Update all PlatformManager instantiations to pass repository path
- Fix test files to use new constructor signature

The root cause was that `gh pr create` and `glab mr create` commands were executing from temporary directories created for markdown files, not the actual git repository.

Resolves #5

Generated with [Claude Code](https://claude.ai/code)