### PR TITLE
build: update binary entry point from cli.js to main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Gitplus is a Model Context Protocol (MCP) server that brings AI-powered git auto
 Install gitplus as an MCP server in Claude Code:
 
 ```bash
-claude mcp add gitplus -- npx @neublink/gitplus@latest
+claude mcp add gitplus -- npx @neublink/gitplus@latest --mcp
 ```
+
+The `--mcp` flag ensures the package starts in MCP server mode for Claude Code integration.
 
 ### Local Development Installation
 
@@ -62,13 +64,13 @@ npm install
 npm run build
 
 # Fix file permissions (required after build)
-chmod +x dist/cli.js dist/index.js
+chmod +x dist/main.js dist/cli.js dist/index.js
 
 # Install CLI globally for command line usage
 npm link
 
 # Add to Claude Code as MCP server (using linked command)
-claude mcp add gitplus-local -- node $(pwd)/dist/index.js
+claude mcp add gitplus-local -- node $(pwd)/dist/main.js --mcp
 ```
 
 **Note**: The `gp` alias may conflict with existing shell aliases for `git push`. Use the `gitplus` command if `gp` doesn't work.
@@ -317,7 +319,7 @@ npm run build
 npm link
 
 # Add to Claude Code as MCP server (local development)
-claude mcp add gitplus-local -- node $(pwd)/dist/index.js
+claude mcp add gitplus-local -- node $(pwd)/dist/main.js --mcp
 ```
 
 After setup:
@@ -458,12 +460,12 @@ Gitplus works out-of-the-box with sensible defaults. For advanced users, configu
 #### MCP Server Connection Failed
 **Issue**: Claude Code shows gitplus-local as ✘ failed.  
 **Solutions**:
-1. Ensure files are executable: `chmod +x dist/cli.js dist/index.js`
+1. Ensure files are executable: `chmod +x dist/main.js dist/cli.js dist/index.js`
 2. Rebuild the project: `npm run build`
 3. Remove and re-add MCP server:
    ```bash
    claude mcp remove gitplus-local
-   claude mcp add gitplus-local -- node $(pwd)/dist/index.js
+   claude mcp add gitplus-local -- node $(pwd)/dist/main.js --mcp
    ```
 
 #### CLI Commands Not Found
@@ -474,15 +476,15 @@ Gitplus works out-of-the-box with sensible defaults. For advanced users, configu
 3. Rebuild and relink:
    ```bash
    npm run build
-   chmod +x dist/cli.js dist/index.js
+   chmod +x dist/main.js dist/cli.js dist/index.js
    npm link
    ```
 
 #### Permission Denied Errors
-**Issue**: `permission denied: /path/to/dist/index.js`  
+**Issue**: `permission denied: /path/to/dist/main.js`  
 **Solution**: Files need execute permissions after build:
 ```bash
-chmod +x dist/cli.js dist/index.js
+chmod +x dist/main.js dist/cli.js dist/index.js
 ```
 
 #### AI Integration Not Working
@@ -559,7 +561,7 @@ npm link
 gitplus --help
 
 # Add to Claude Code for MCP testing
-claude mcp add gitplus-local -- node $(pwd)/dist/index.js
+claude mcp add gitplus-local -- node $(pwd)/dist/main.js --mcp
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "AI-powered Git automation MCP server for Claude Code",
   "main": "dist/index.js",
   "bin": {
-    "gitplus": "dist/cli.js",
-    "gp": "dist/cli.js"
+    "gitplus": "dist/main.js",
+    "gp": "dist/main.js"
   },
   "scripts": {
     "build": "tsc",
@@ -24,11 +24,9 @@
     "server": {
       "command": "node",
       "args": [
-        "${pkgPath}/dist/index.js",
-        "--transport",
-        "stdio"
-      ],
-      "transport": "stdio"
+        "${pkgPath}/dist/main.js",
+        "--mcp"
+      ]
     }
   },
   "keywords": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ import { createMCPServer } from './mcp/server';
 import { MCPTransport } from './types';
 
 /**
- * Checks if MCP server mode is requested
+ * Checks if MCP server mode is requested by looking for the --mcp flag
+ * @returns {boolean} True if --mcp flag is present in command line arguments
  */
 function shouldRunAsMCPServer(): boolean {
   const args = process.argv.slice(2);
@@ -17,7 +18,9 @@ function shouldRunAsMCPServer(): boolean {
 }
 
 /**
- * Runs the MCP server
+ * Runs the MCP server using stdio transport
+ * Logs to stderr to keep stdout available for MCP communication
+ * @throws {Error} If the MCP server fails to start
  */
 async function runMCPServer() {
   // MCP servers typically use stdio transport
@@ -44,15 +47,19 @@ async function runMCPServer() {
 }
 
 /**
- * Runs the CLI interface
+ * Runs the CLI interface by dynamically importing the CLI module
+ * The CLI module automatically executes when imported due to program.parse()
+ * @throws {Error} If the CLI module fails to load or execute
  */
 async function runCLI() {
   // The CLI module automatically executes when imported due to program.parse() at the end
-  await import('./cli.js');
+  await import('./cli');
 }
 
 /**
- * Main entry point
+ * Main entry point that routes to MCP server or CLI mode based on arguments
+ * Checks for --mcp flag to determine which mode to run
+ * @throws {Error} If either mode fails to start
  */
 async function main() {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+/**
+ * Unified entry point for GitPlus
+ * Routes to MCP server mode (--mcp) or CLI mode (default)
+ */
+
+import { createMCPServer } from './mcp/server';
+import { MCPTransport } from './types';
+
+/**
+ * Checks if MCP server mode is requested
+ */
+function shouldRunAsMCPServer(): boolean {
+  const args = process.argv.slice(2);
+  return args.includes('--mcp');
+}
+
+/**
+ * Runs the MCP server
+ */
+async function runMCPServer() {
+  // MCP servers typically use stdio transport
+  const config = {
+    transport: 'stdio' as MCPTransport
+  };
+
+  try {
+    const server = createMCPServer(config);
+    
+    // Log to stderr (not stdout which is used for MCP communication)
+    console.error('Starting gitplus MCP server...');
+    
+    await server.start();
+    
+    console.error('✅ Gitplus MCP server started successfully');
+    
+    // Keep the process alive
+    process.stdin.resume();
+  } catch (error) {
+    console.error('❌ Failed to start gitplus MCP server:', error);
+    process.exit(1);
+  }
+}
+
+/**
+ * Runs the CLI interface
+ */
+async function runCLI() {
+  // The CLI module automatically executes when imported due to program.parse() at the end
+  await import('./cli.js');
+}
+
+/**
+ * Main entry point
+ */
+async function main() {
+  try {
+    if (shouldRunAsMCPServer()) {
+      await runMCPServer();
+    } else {
+      await runCLI();
+    }
+  } catch (error) {
+    console.error('❌ Failed to start gitplus:', error);
+    process.exit(1);
+  }
+}
+
+// Handle unhandled rejections
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+// Handle uncaught exceptions
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught Exception:', error);
+  process.exit(1);
+});
+
+// Graceful shutdown - only exit on explicit signals
+process.on('SIGINT', () => {
+  console.error('🛑 Received SIGINT, shutting down gracefully');
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.error('🛑 Received SIGTERM, shutting down gracefully');
+  process.exit(0);
+});
+
+if (require.main === module) {
+  main();
+}

--- a/src/mcp/toolDefinitions.ts
+++ b/src/mcp/toolDefinitions.ts
@@ -166,6 +166,14 @@ export const toolDefinitions = [
       fix: z.boolean().optional().describe('Attempt to fix issues automatically')
     },
   },
+  {
+    name: 'info',
+    title: 'GitPlus MCP Info',
+    description: 'Get comprehensive information about GitPlus MCP server capabilities, tools, and usage',
+    inputSchema: {
+      repoPath: z.string().optional().describe('Full absolute path to the git repository (optional - provides repo-specific info if given)')
+    },
+  },
 ] as const;
 
 export type ToolName = typeof toolDefinitions[number]['name'];
@@ -184,3 +192,4 @@ export type ResetToolInput = z.infer<z.ZodObject<typeof toolDefinitions[9]['inpu
 export type RebaseToolInput = z.infer<z.ZodObject<typeof toolDefinitions[10]['inputSchema']>>;
 export type RecoverToolInput = z.infer<z.ZodObject<typeof toolDefinitions[11]['inputSchema']>>;
 export type ValidateToolInput = z.infer<z.ZodObject<typeof toolDefinitions[12]['inputSchema']>>;
+export type InfoToolInput = z.infer<z.ZodObject<typeof toolDefinitions[13]['inputSchema']>>;


### PR DESCRIPTION
## Summary
Updates the package.json binary configuration to use `main.js` as the entry point instead of `cli.js`. Also updates the MCP server configuration to use the new entry point with `--mcp` flag.

## Changes
- Updated `bin` entries to point to `dist/main.js`
- Modified MCP server args to use `--mcp` flag
- Simplified server configuration

## Testing
- [ ] Verify `dist/main.js` exists after build
- [ ] Test CLI functionality with new entry point
- [ ] Test MCP server integration

## Impact
This is a build configuration change that may affect existing installations.