### PR TITLE
fix(ci): correct Release Please author and add explicit username validation

### DIFF
--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           # Validate GitHub username format  
-          if [ -z "$RAW_PR_AUTHOR" ] || ! [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-\[\]]{0,39}[a-zA-Z0-9\]])?$ ]]; then
+          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]]); then
             echo "❌ ERROR: PR author name does not match expected GitHub username format"
             exit 1
           fi

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           # Validate GitHub username format  
-          if [ -z "$RAW_PR_AUTHOR" ] || ! [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]]; then
+          if [ -z "$RAW_PR_AUTHOR" ] || ! [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-\[\]]{0,39}[a-zA-Z0-9\]])?$ ]]; then
             echo "❌ ERROR: PR author name does not match expected GitHub username format"
             exit 1
           fi
@@ -221,7 +221,7 @@ jobs:
           AUTHOR="$RAW_PR_AUTHOR"
           HEAD_BRANCH="$RAW_HEAD_BRANCH"
           IS_RELEASE_PLEASE="false"
-          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             IS_RELEASE_PLEASE="true"
             echo "Detected Release Please PR"
           fi
@@ -325,7 +325,7 @@ jobs:
           echo "🔒 Validating Release Please PR security..."
           # Security validation: Strict author verification using environment variables
           
-          if [ "$AUTHOR" != "app/github-actions" ]; then
+          if [ "$AUTHOR" != "github-actions[bot]" ]; then
             echo "❌ SECURITY VIOLATION: Invalid Release Please author: $AUTHOR"
             echo "release_validation_passed=false" >> $GITHUB_OUTPUT
             exit 1
@@ -656,7 +656,7 @@ jobs:
           **Action**: $RECOMMENDED_ACTION  
           
           **Security Validation**: ✅ Passed
-          - Author verified: app/github-actions
+          - Author verified: github-actions[bot]
           - Branch pattern verified: release-please--*
           - File changes validated: Only safe release files
           
@@ -1068,7 +1068,7 @@ jobs:
           fi
           
           # Determine merge method
-          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$PR_AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             echo "🔄 Release Please PR detected"
             echo "merge_method=squash" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           # Validate GitHub username format  
-          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]]); then
+          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]] || [[ "$RAW_PR_AUTHOR" = "app/github-actions" ]]); then
             echo "❌ ERROR: PR author name does not match expected GitHub username format"
             exit 1
           fi
@@ -221,7 +221,7 @@ jobs:
           AUTHOR="$RAW_PR_AUTHOR"
           HEAD_BRANCH="$RAW_HEAD_BRANCH"
           IS_RELEASE_PLEASE="false"
-          if [[ "$AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             IS_RELEASE_PLEASE="true"
             echo "Detected Release Please PR"
           fi
@@ -325,7 +325,7 @@ jobs:
           echo "🔒 Validating Release Please PR security..."
           # Security validation: Strict author verification using environment variables
           
-          if [ "$AUTHOR" != "github-actions[bot]" ]; then
+          if [ "$AUTHOR" != "app/github-actions" ]; then
             echo "❌ SECURITY VIOLATION: Invalid Release Please author: $AUTHOR"
             echo "release_validation_passed=false" >> $GITHUB_OUTPUT
             exit 1
@@ -656,7 +656,7 @@ jobs:
           **Action**: $RECOMMENDED_ACTION  
           
           **Security Validation**: ✅ Passed
-          - Author verified: github-actions[bot]
+          - Author verified: app/github-actions
           - Branch pattern verified: release-please--*
           - File changes validated: Only safe release files
           
@@ -1068,7 +1068,7 @@ jobs:
           fi
           
           # Determine merge method
-          if [[ "$PR_AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             echo "🔄 Release Please PR detected"
             echo "merge_method=squash" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR completes the fix for the merge-decision workflow failing on Release Please PRs.

## Root Cause Discovery

After testing the initial fix, I discovered that the actual Release Please author is **app/github-actions**, not **github-actions[bot]** as initially assumed.

## Final Fixes Applied

1. **Username Validation**: Added triple-pattern validation to handle:
   - Regular GitHub usernames: 
   - Bot usernames: 
   - **Release Please specific**:  (exact match)

2. **Author Matching**: Corrected all author checks back to 'app/github-actions' (4 locations)

## Testing

This fix addresses the username validation error that was preventing the merge-decision workflow from running for PR #37.

## Files Changed

-  - Fixed username validation and author matching

Fixes #37 workflow issues (final fix).