### PR TITLE
fix(ci): correct Release Please author validation format

### DIFF
--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           # Validate GitHub username format  
-          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]]); then
+          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]] || [[ "$RAW_PR_AUTHOR" = "app/github-actions" ]]); then
             echo "❌ ERROR: PR author name does not match expected GitHub username format"
             exit 1
           fi
@@ -221,7 +221,7 @@ jobs:
           AUTHOR="$RAW_PR_AUTHOR"
           HEAD_BRANCH="$RAW_HEAD_BRANCH"
           IS_RELEASE_PLEASE="false"
-          if [[ "$AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             IS_RELEASE_PLEASE="true"
             echo "Detected Release Please PR"
           fi
@@ -325,7 +325,7 @@ jobs:
           echo "🔒 Validating Release Please PR security..."
           # Security validation: Strict author verification using environment variables
           
-          if [ "$AUTHOR" != "github-actions[bot]" ]; then
+          if [ "$AUTHOR" != "app/github-actions" ]; then
             echo "❌ SECURITY VIOLATION: Invalid Release Please author: $AUTHOR"
             echo "release_validation_passed=false" >> $GITHUB_OUTPUT
             exit 1
@@ -656,7 +656,7 @@ jobs:
           **Action**: $RECOMMENDED_ACTION  
           
           **Security Validation**: ✅ Passed
-          - Author verified: github-actions[bot]
+          - Author verified: app/github-actions
           - Branch pattern verified: release-please--*
           - File changes validated: Only safe release files
           
@@ -1068,7 +1068,7 @@ jobs:
           fi
           
           # Determine merge method
-          if [[ "$PR_AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             echo "🔄 Release Please PR detected"
             echo "merge_method=squash" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes Release Please PR validation by updating the expected author format from `github-actions[bot]` to `app/github-actions` throughout the merge decision workflow.

## Changes

- Updated author validation regex to accept `app/github-actions` format
- Fixed Release Please detection logic in multiple workflow steps
- Corrected security validation checks for Release Please PRs
- Updated comment templates to reflect correct author format

## Impact

- ✅ Release Please PRs will now be properly validated and processed
- ✅ Maintains security validation while fixing format mismatch
- ✅ Ensures automated release workflow continues functioning

## Testing

- [ ] Verify with actual Release Please PR creation
- [ ] Confirm author format matches GitHub's current implementation
- [ ] Test security validation still works correctly