### PR TITLE
fix(ci): resolve merge-decision workflow issues for Release Please PRs

### DIFF
--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -221,7 +221,7 @@ jobs:
           AUTHOR="$RAW_PR_AUTHOR"
           HEAD_BRANCH="$RAW_HEAD_BRANCH"
           IS_RELEASE_PLEASE="false"
-          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--branches--main--components-- ]]; then
             IS_RELEASE_PLEASE="true"
             echo "Detected Release Please PR"
           fi
@@ -1082,7 +1082,7 @@ jobs:
           fi
           
           # Determine merge method
-          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--branches--main--components-- ]]; then
             echo "🔄 Release Please PR detected"
             echo "merge_method=squash" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -191,7 +191,7 @@ jobs:
           fi
           
           # Validate GitHub username format  
-          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]]); then
+          if [ -z "$RAW_PR_AUTHOR" ] || ! ([[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$ ]] || [[ "$RAW_PR_AUTHOR" =~ ^[a-zA-Z0-9-]+\[bot\]$ ]] || [[ "$RAW_PR_AUTHOR" = "app/github-actions" ]]); then
             echo "❌ ERROR: PR author name does not match expected GitHub username format"
             exit 1
           fi
@@ -221,7 +221,7 @@ jobs:
           AUTHOR="$RAW_PR_AUTHOR"
           HEAD_BRANCH="$RAW_HEAD_BRANCH"
           IS_RELEASE_PLEASE="false"
-          if [[ "$AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             IS_RELEASE_PLEASE="true"
             echo "Detected Release Please PR"
           fi
@@ -325,7 +325,7 @@ jobs:
           echo "🔒 Validating Release Please PR security..."
           # Security validation: Strict author verification using environment variables
           
-          if [ "$AUTHOR" != "github-actions[bot]" ]; then
+          if [ "$AUTHOR" != "app/github-actions" ]; then
             echo "❌ SECURITY VIOLATION: Invalid Release Please author: $AUTHOR"
             echo "release_validation_passed=false" >> $GITHUB_OUTPUT
             exit 1
@@ -656,7 +656,7 @@ jobs:
           **Action**: $RECOMMENDED_ACTION  
           
           **Security Validation**: ✅ Passed
-          - Author verified: github-actions[bot]
+          - Author verified: app/github-actions
           - Branch pattern verified: release-please--*
           - File changes validated: Only safe release files
           
@@ -1068,7 +1068,7 @@ jobs:
           fi
           
           # Determine merge method
-          if [[ "$PR_AUTHOR" == "github-actions[bot]" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
+          if [[ "$PR_AUTHOR" == "app/github-actions" ]] && [[ "$HEAD_BRANCH" =~ ^release-please--[a-zA-Z0-9._-]{1,50}$ ]]; then
             echo "🔄 Release Please PR detected"
             echo "merge_method=squash" >> $GITHUB_OUTPUT
             echo "is_release=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -227,11 +227,25 @@ jobs:
           fi
           echo "IS_RELEASE_PLEASE=$IS_RELEASE_PLEASE" >> $GITHUB_OUTPUT
           
+          # Get HEAD SHA from PR data if not available from event (workflow_dispatch case)
+          if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+            echo "🔍 HEAD SHA not available from event, fetching from PR data..."
+            HEAD_SHA=$(echo "$PR_DATA" | jq -r '.commits[-1].oid // empty')
+            if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+              # Fallback to direct API call
+              HEAD_SHA=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')
+            fi
+            echo "📄 Retrieved HEAD SHA: $HEAD_SHA"
+          fi
+          
           # Validate HEAD SHA format
           if ! [[ "$HEAD_SHA" =~ ^[a-f0-9]{40}$ ]] || [ ${#HEAD_SHA} -ne 40 ]; then
             echo "❌ ERROR: Invalid HEAD SHA format: $HEAD_SHA"
             exit 1
           fi
+          
+          # Export HEAD SHA for later steps
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_OUTPUT
           
           # Get detailed CI check information
           echo "🔍 Gathering detailed CI check information..."
@@ -311,7 +325,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.wait-for-checks.outputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ steps.pr-context.outputs.HEAD_SHA || github.event.pull_request.head.sha }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -892,7 +906,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          COMMIT_SHA: ${{ steps.pr-context.outputs.HEAD_SHA || github.event.pull_request.head.sha || github.sha }}
           PR_NUMBER: ${{ steps.pr-context.outputs.PR_NUMBER }}
           IS_RELEASE_PLEASE: ${{ steps.pr-context.outputs.IS_RELEASE_PLEASE }}
           RECOMMENDED_ACTION: ${{ steps.parse-decision.outputs.RECOMMENDED_ACTION }}
@@ -921,7 +935,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          COMMIT_SHA: ${{ steps.pr-context.outputs.HEAD_SHA || github.event.pull_request.head.sha || github.sha }}
           REASON: ${{ steps.parse-decision.outputs.REASON }}
           RECOMMENDED_ACTION: ${{ steps.parse-decision.outputs.RECOMMENDED_ACTION }}
 
@@ -949,7 +963,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          COMMIT_SHA: ${{ steps.pr-context.outputs.HEAD_SHA || github.event.pull_request.head.sha || github.sha }}
           REASON: ${{ steps.parse-decision.outputs.REASON }}
           CRITICAL_ISSUES: ${{ steps.parse-decision.outputs.CRITICAL_ISSUES }}
 


### PR DESCRIPTION
## Summary

Fixes critical issues preventing the merge-decision workflow from working correctly with Release Please PRs:

### Issues Fixed:
1. **HEAD_SHA handling in workflow_dispatch**: Added logic to fetch HEAD SHA from PR data when not available from event context
2. **Release Please detection**: Updated branch pattern regex to match actual Release Please branch format  
3. **Author validation**: Ensured proper author checking for app/github-actions

### Root Cause:
The merge-decision workflow was failing when triggered manually (workflow_dispatch) for Release Please PRs because:
- HEAD_SHA was null in workflow_dispatch context, causing validation to fail
- Branch pattern regex was too restrictive and didn't match the actual format: 
- Author validation logic had discrepancies

### Solution:
- Added fallback logic to fetch HEAD_SHA from PR API when event context is empty
- Updated regex pattern to match the specific Release Please branch format
- Fixed environment variable references to use step outputs instead of event context
- Added proper validation and export of HEAD_SHA for downstream steps

### Test Plan:
- [x] Manual trigger of merge-decision workflow for PR #39 (Release Please)
- [x] Verify Release Please detection works correctly
- [x] Verify HEAD_SHA is properly fetched and validated
- [x] Verify workflow completes successfully for Release Please PRs

This resolves the stuck release job issue and ensures the CI/CD pipeline can process Release Please PRs correctly.

Fixes #39 (Release Please PR stuck waiting on merge-decision)