### PR TITLE
fix(ci): publish release-please tags to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'gitplus-v*'
 
 jobs:
   test:
@@ -56,75 +57,8 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  create-github-release:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Build project
-      run: npm run build
-      
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Extract version from tag
-        VERSION=${GITHUB_REF#refs/tags/v}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        
-        # Generate changelog from commits since last tag
-        LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-        if [ -n "$LAST_TAG" ]; then
-          CHANGELOG=$(git log --pretty=format:"- %s (%h)" $LAST_TAG..HEAD)
-        else
-          CHANGELOG=$(git log --pretty=format:"- %s (%h)" --max-count=10)
-        fi
-        
-        # Create changelog file
-        cat > CHANGELOG.md << EOF
-        # Release v$VERSION
-        
-        ## Changes
-        $CHANGELOG
-        
-        ## Installation
-        \`\`\`bash
-        # Install as MCP server in Claude Code
-        claude mcp add gitplus -- npx @neublink/gitplus@$VERSION
-        
-        # Or install CLI globally
-        npm install -g @neublink/gitplus@$VERSION
-        \`\`\`
-        
-        ## Full Changelog
-        https://github.com/neublink/gitplus/compare/$LAST_TAG...v$VERSION
-        EOF
-        
-    - name: Create GitHub Release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4adc7b913fd # v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ steps.changelog.outputs.version }}
-        body_path: CHANGELOG.md
-        draft: false
-        prerelease: false
-
   test-published-package:
-    needs: [publish-npm, create-github-release]
+    needs: publish-npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -135,10 +69,12 @@ jobs:
     - name: Test NPM installation
       run: |
         # Extract version from tag
-        VERSION=${GITHUB_REF#refs/tags/v}
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        VERSION=${TAG_NAME#gitplus-v}
+        VERSION=${VERSION#v}
         
         # Test global CLI installation
-        npm install -g @neublink/gitplus@$VERSION
+        npm install -g "@neublink/gitplus@$VERSION"
         
         # Test CLI commands
         gitplus --version


### PR DESCRIPTION
## Summary
- trigger the npm release workflow for Release Please tags like `gitplus-v1.2.1`
- remove duplicate GitHub release creation from the npm publish workflow
- parse both `v*` and `gitplus-v*` tag formats when testing the published package

## Validation
- `actionlint .github/workflows/release.yml`
- Ruby YAML parse for `.github/workflows/release.yml`
- `git diff --check`