### PR TITLE
fix(ci): use release token for release PR auto-merge

### DIFF
--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -937,7 +937,7 @@ jobs:
             -f description="$DESCRIPTION" \
             -f context="merge-decision" 2>/dev/null || echo "::warning::Status creation failed"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.pr-context.outputs.IS_RELEASE_PLEASE == 'true' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ steps.pr-context.outputs.HEAD_SHA || github.event.pull_request.head.sha || github.sha }}
           PR_NUMBER: ${{ steps.pr-context.outputs.PR_NUMBER }}
@@ -1225,7 +1225,7 @@ jobs:
             fi
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.check-merge.outputs.is_release == 'true' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           MERGE_METHOD: ${{ steps.check-merge.outputs.merge_method }}
           IS_RELEASE: ${{ steps.check-merge.outputs.is_release }}


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN` when merge-decision auto-merges Release Please PRs.
- Keep regular PR auto-merge on `GITHUB_TOKEN`.

## Why
Release Please PR #52 merged successfully, but because the auto-merge used `GITHUB_TOKEN`, GitHub did not trigger the `push` workflow that would have let Release Please create the tag/release automatically. We had to push `gitplus-v1.3.0` manually to publish npm.

## Validation
- `actionlint -shellcheck= .github/workflows/merge-decision.yml`
- `git diff --check -- .github/workflows/merge-decision.yml`

## Note
This PR modifies the workflow that runs the Claude-backed merge decision. If GitHub rejects the Claude action app-token exchange because the workflow differs from `main`, this needs a maintainer/admin merge after reviewing the two-line token-source change.
