### PR TITLE
fix(ci): direct merge approved PRs with automation token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -117,7 +117,7 @@ jobs:
             REVIEW_DATA=$(echo "$ALL_COMMENTS" | jq -c \
               --arg min_length "$MIN_REVIEW_LENGTH" \
               --arg run_id "$GITHUB_RUN_ID" \
-              '.comments | map(select(.author.login == "claude" and (.body | contains($run_id)) and (.body | length > ($min_length | tonumber)))) | last // empty | {body: .body, length: (.body | length)}')
+              '.comments | map(select((.author.login == "claude" or .author.login == "github-actions") and (.body | contains($run_id)) and (.body | length > ($min_length | tonumber)))) | last // empty | {body: .body, length: (.body | length)}')
             
             if [ -n "$REVIEW_DATA" ] && [ "$REVIEW_DATA" != "null" ]; then
               POTENTIAL_REVIEW=$(echo "$REVIEW_DATA" | jq -r '.body')

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@e26577a930883943cf9d90885cd1e8da510078dd # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -61,4 +62,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -344,7 +344,7 @@ jobs:
           REQUIRE_CLAUDE_REVIEW: ${{ vars.REQUIRE_CLAUDE_REVIEW }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -1184,7 +1184,7 @@ jobs:
           DECISION: ${{ needs.merge-decision.outputs.DECISION }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
-      - name: Execute auto-merge
+      - name: Execute regular direct-merge
         if: |
           steps.check-merge.outputs.eligible == 'true' &&
           steps.check-merge.outputs.is_release != 'true' &&
@@ -1192,9 +1192,12 @@ jobs:
            (needs.merge-decision.outputs.DECISION == 'MANUAL_APPROVAL' && 
             needs.merge-decision.outputs.RECOMMENDED_ACTION == 'auto-merge'))
         run: |
-          # All values now come from environment variables
-          
-          echo "🚀 Auto-merging PR #$PR_NUMBER"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Regular merge credential is not configured"
+            exit 1
+          fi
+
+          echo "🚀 Direct-merging regular PR #$PR_NUMBER"
           echo "📋 Decision: $DECISION"
           echo "🔧 Method: $MERGE_METHOD"
           
@@ -1217,62 +1220,40 @@ jobs:
             exit 0
           fi
           
-          # Try auto-merge first (GitHub's auto-merge feature)
-          echo "🔄 Attempting to enable auto-merge with $MERGE_METHOD method..."
-          AUTO_MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "--$MERGE_METHOD" --auto 2>&1) || AUTO_MERGE_FAILED=true
-          
-          if [ -z "$AUTO_MERGE_FAILED" ]; then
-            echo "✅ Successfully enabled auto-merge for PR #$PR_NUMBER"
-            echo "📋 Auto-merge output: $AUTO_MERGE_OUTPUT"
+          echo "🔄 Attempting direct merge with $MERGE_METHOD method..."
+          DIRECT_MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "--$MERGE_METHOD" 2>&1) || DIRECT_MERGE_FAILED=true
+
+          if [ -z "$DIRECT_MERGE_FAILED" ]; then
+            echo "✅ Successfully merged PR #$PR_NUMBER directly"
+            echo "📋 Direct merge output: $DIRECT_MERGE_OUTPUT"
             
             gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --body "🤖 **Auto-merge Enabled** by GitPlus\\n\\n✅ **Decision**: $DECISION\\n🚀 **Method**: $MERGE_METHOD\\n\\nThis PR will be automatically merged once all required status checks pass."
+              --body "🤖 **PR Merged** by GitPlus\\n\\n✅ **Decision**: $DECISION\\n🚀 **Method**: $MERGE_METHOD\\n🔑 **Merge path**: regular direct merge\\n\\nThis PR was merged directly with a repository credential so downstream workflows can run."
               
           else
-            echo "⚠️ Auto-merge failed: $AUTO_MERGE_OUTPUT"
-            echo "🔄 Attempting direct merge..."
+            echo "❌ Direct merge failed: $DIRECT_MERGE_OUTPUT"
+            echo "📋 Analyzing failure reasons..."
             
-            # Try immediate merge
-            DIRECT_MERGE_OUTPUT=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "--$MERGE_METHOD" 2>&1) || DIRECT_MERGE_FAILED=true
-            
-            if [ -z "$DIRECT_MERGE_FAILED" ]; then
-              echo "✅ Successfully merged PR #$PR_NUMBER directly"
-              echo "📋 Direct merge output: $DIRECT_MERGE_OUTPUT"
-              
-              gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                --body "🤖 **PR Merged** by GitPlus\\n\\n✅ **Decision**: $DECISION\\n🚀 **Method**: $MERGE_METHOD\\n\\nThis PR has been automatically merged."
-                
+            # Provide detailed failure analysis
+            if echo "$DIRECT_MERGE_OUTPUT" | grep -q "Resource not accessible"; then
+              echo "❌ Permission issue detected"
+              FAILURE_REASON="Insufficient workflow permissions for merging"
+            elif echo "$DIRECT_MERGE_OUTPUT" | grep -q "branch protection"; then
+              echo "❌ Branch protection rule violation"
+              FAILURE_REASON="Branch protection rules prevent automatic merging"
+            elif echo "$DIRECT_MERGE_OUTPUT" | grep -q "required status checks"; then
+              echo "❌ Required status checks not satisfied"
+              FAILURE_REASON="Required status checks have not passed"
             else
-              echo "❌ Direct merge also failed: $DIRECT_MERGE_OUTPUT"
-              echo "📋 Analyzing failure reasons..."
-              
-              # Provide detailed failure analysis
-              if echo "$DIRECT_MERGE_OUTPUT" | grep -q "Resource not accessible"; then
-                echo "❌ Permission issue detected"
-                FAILURE_REASON="Insufficient workflow permissions for merging"
-              elif echo "$DIRECT_MERGE_OUTPUT" | grep -q "branch protection"; then
-                echo "❌ Branch protection rule violation"
-                FAILURE_REASON="Branch protection rules prevent automatic merging"
-              elif echo "$DIRECT_MERGE_OUTPUT" | grep -q "required status checks"; then
-                echo "❌ Required status checks not satisfied"
-                FAILURE_REASON="Required status checks have not passed"
-              else
-                echo "❌ Unknown merge failure"
-                FAILURE_REASON="Unknown error during merge operation"
-              fi
-              
-              gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                --body "⚠️ **Auto-merge Failed**\\n\\n✅ **Decision**: $DECISION (approved by GitPlus AI)\\n❌ **Issue**: $FAILURE_REASON\\n\\n**Error Details:**\\n\\\`\\\`\\\`\\n$DIRECT_MERGE_OUTPUT\\n\\\`\\\`\\\`\\n\\n**Manual Action Required**: Please merge this PR manually or review repository settings."
-              
-              # Set output but don't fail the workflow
-              {
-                echo "auto_merge_failed=true"
-                echo "failure_reason=$FAILURE_REASON"
-              } >> "$GITHUB_OUTPUT"
+              echo "❌ Unknown merge failure"
+              FAILURE_REASON="Unknown error during merge operation"
             fi
+
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --body "⚠️ **Direct Merge Failed**\\n\\n✅ **Decision**: $DECISION (approved by GitPlus AI)\\n❌ **Issue**: $FAILURE_REASON\\n\\n**Error Details:**\\n\\\`\\\`\\\`\\n$DIRECT_MERGE_OUTPUT\\n\\\`\\\`\\\`\\n\\n**Manual Action Required**: Please merge this PR manually or review repository settings."
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           MERGE_METHOD: ${{ steps.check-merge.outputs.merge_method }}
           DECISION: ${{ needs.merge-decision.outputs.DECISION }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,7 @@
 name: Release Please
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -304,17 +304,9 @@ GitPlus will handle all git operations intelligently, ensuring proper commit mes
 
 ## Publishing & Release
 
-Use the GitHub Actions workflow to publish:
+Releases are managed by Release Please. Conventional commits merged to `main` update the release PR; merging that PR creates the GitHub release and tag, then the tag-triggered release workflow publishes to npm.
 
-1. **Go to Actions tab** in GitHub repository
-2. **Select "Manual Publish"** workflow  
-3. **Choose version bump**: patch, minor, or major
-4. **Click "Run workflow"** to automatically:
-   - Run full test suite
-   - Build the package
-   - Bump version and create git tag
-   - Publish to NPM registry
-   - Create GitHub release with changelog
+For required secrets, verification, and manual recovery steps, see [docs/release-runbook.md](docs/release-runbook.md).
 
 ## Contributing
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,37 @@
+# Release Runbook
+
+GitPlus releases are managed by Release Please and GitHub Actions.
+
+## Required Secrets
+
+- `RELEASE_PLEASE_TOKEN`: Fine-grained PAT or GitHub App token that can merge approved PRs, trigger downstream workflows, and create release PRs, labels, tags, and releases. Do not use the default `GITHUB_TOKEN`; bot-authored PRs from `GITHUB_TOKEN` do not trigger required downstream workflows.
+- `NPM_TOKEN`: npm automation token with publish access for `@neublink/gitplus`.
+- `CLAUDE_CODE_OAUTH_TOKEN`: Claude Code OAuth token used by Claude-related CI workflows.
+
+## Expected Flow
+
+1. Merge conventional commits to `main`.
+2. `Release Please` runs on the `main` push and opens or updates the release PR.
+3. Maintainers review and merge the release PR.
+4. Release Please creates the GitHub release and tag.
+5. `.github/workflows/release.yml` runs on the tag, validates the package, publishes to npm, and smoke-tests the published package.
+
+## Verify a Release
+
+- GitHub: confirm the tag and release exist at `https://github.com/neublink/gitplus/releases`.
+- GitHub Actions: confirm the `Release` workflow completed successfully for the release tag.
+- npm: run `npm view @neublink/gitplus version` and confirm it matches the GitHub release.
+- Install smoke test: run `npm install -g @neublink/gitplus@<version>` and then `gitplus --version`.
+
+## Manual Recovery
+
+Use this when a bot-authored merge or missed event suppresses the expected push workflow.
+
+1. Open GitHub Actions and select `Release Please`.
+2. Click `Run workflow` on `main`.
+3. Confirm the run uses `RELEASE_PLEASE_TOKEN` and completes successfully.
+4. If a release PR is opened or updated, merge it after checks pass.
+5. Confirm the tag-triggered `Release` workflow starts. If it does not, rerun `Release Please` once after verifying the tag was not already created.
+6. Verify GitHub and npm using the checks above.
+
+If npm publish failed after the GitHub release was created, rerun the failed `Release` workflow job after confirming `NPM_TOKEN` is still valid and the package version has not already been published.


### PR DESCRIPTION
## Summary
- direct-merge regular approved PRs with the automation token instead of GitHub built-in auto-merge
- add manual Release Please dispatch and a release recovery runbook
- pass explicit GitHub tokens to Claude workflows and update remaining checkout v4 usages to v6

## Validation
- actionlint -shellcheck= .github/workflows/*.yml
- git diff --check
- npm run validate