### PR TITLE
feat(agent): add agent adoption init command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 3. **No Manual Git Commands**: Always use GitPlus MCP tools instead of manual git commands.
 
-4. **3-Tool Limit**: Resist adding more MCP tools. Enhance existing tools instead.
+4. **3-Tool Limit**: Resist adding more MCP tools. Enhance existing tools instead. This limit applies to the MCP surface; CLI-only agent lifecycle commands are acceptable when they keep the MCP API small and help coding agents coordinate work safely.
 
 ## CI/CD Pipeline
 

--- a/CLI.md
+++ b/CLI.md
@@ -6,6 +6,8 @@ This document describes the CLI interface for GitPlus. **Note**: The CLI is seco
 
 GitPlus provides a comprehensive CLI interface with 14+ commands for advanced git operations. The CLI is designed for direct command-line usage and offers more granular control than the simplified MCP interface.
 
+The MCP interface remains intentionally small. Agent lifecycle commands such as `init-agent`, `start`, `claim`, and `checkpoint` are CLI-only coordination helpers; they do not expand the MCP tool surface.
+
 ## Installation
 
 The CLI is automatically available after installing GitPlus:
@@ -23,7 +25,7 @@ After linking, both `gitplus` and `gp` commands are available globally.
 
 Before using the CLI, ensure you have:
 
-- **Node.js 16+**: Required runtime environment
+- **Node.js 18+**: Required runtime environment
 - **Claude CLI**: Install and authenticate with `claude auth login`
   ```bash
   # Verify Claude CLI is available and authenticated
@@ -52,6 +54,10 @@ export GITPLUS_CLAUDE_COMMAND="claude"           # Claude CLI command path (defa
 
 | Command | Alias | Description |
 |---------|-------|-------------|
+| `gitplus init-agent` | | Install GitPlus instructions for Codex, Claude, Gemini, or all agents |
+| `gitplus start` | | Start an isolated agent run and worktree |
+| `gitplus claim` | | Claim paths for the current agent run |
+| `gitplus checkpoint` | | Record an agent checkpoint with validation context |
 | `gitplus commit` | `gp commit`* | AI-powered conventional commits |
 | `gitplus ship` | `gp ship`* | Complete workflow: commit → push → PR |
 | `gitplus analyze` | `gp analyze`* | AI analysis of repository changes |
@@ -67,6 +73,57 @@ export GITPLUS_CLAUDE_COMMAND="claude"           # Claude CLI command path (defa
 *Note: `gp` alias may conflict with existing shell aliases for `git push`
 
 ## Command Reference
+
+### `gitplus init-agent` - Agent Adoption Setup
+
+Install managed GitPlus instructions for coding agents. This is the fastest path to make Codex, Claude, Gemini, or all three use GitPlus for git operations.
+
+```bash
+# Install all supported agent surfaces
+gitplus init-agent
+gitplus init-agent --agent all
+
+# Install one agent surface
+gitplus init-agent --agent codex
+gitplus init-agent --agent claude
+gitplus init-agent --agent gemini
+
+# Positional form also works
+gitplus init-agent codex
+```
+
+**Generated surfaces:**
+- `AGENTS.md`
+- `CLAUDE.md`
+- `GEMINI.md`
+- `.agents/skills/gitplus/SKILL.md`
+- `.claude/skills/gitplus/SKILL.md`
+- `.gemini/commands/git/ship.toml`
+
+The installer is idempotent. It replaces only the GitPlus-managed block and preserves surrounding project-specific instructions.
+
+### Agent Run Commands
+
+Use these commands when an agent is doing repository work directly from the CLI.
+
+```bash
+# Start an isolated worktree-backed run
+gitplus start --agent codex --task "implement invoice validation"
+
+# Show branch, working tree, and current run context
+gitplus status --verbose
+
+# Claim files before overlapping edits
+gitplus claim src/invoices tests/invoices
+
+# Record progress and validation context
+gitplus checkpoint --summary "added invoice validation tests" --test "npm test -- invoices"
+
+# Commit, push, and open the PR
+gitplus ship
+```
+
+For parallel agents, start one run per agent, keep each agent on its own GitPlus branch/worktree, claim shared paths before editing, and checkpoint before handoff or conflict-prone changes.
 
 ### `gitplus commit` - AI-Powered Commits
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# GitPlus - AI-Powered Git Automation for Claude Code
+# GitPlus - Git Workflows for Coding Agents
 
 [![CI](https://github.com/neublink/gitplus/workflows/CI/badge.svg)](https://github.com/neublink/gitplus/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D16.0.0-brightgreen)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
 
-GitPlus is a Model Context Protocol (MCP) server that brings AI-powered git automation directly to Claude Code. It provides a simplified, intelligent interface with just 3 essential tools that handle complete git workflows automatically.
+GitPlus gives coding agents a safer git workflow: isolated worktrees, path claims, checkpoints, status context, conventional commits, pull request creation, and release-friendly shipping. It works as a CLI for Codex, Claude, Gemini, and other coding agents, and it still includes a Model Context Protocol (MCP) server for Claude Code.
 
 ## Features
 
 🚀 **Complete Git Workflows**: One-command ship from changes to PR  
 💻 **Smart Commits**: AI-generated conventional commit messages with strict spec compliance  
 🔍 **Change Analysis**: Intelligent analysis of repository changes with breaking change detection  
+🤖 **Agent-Native**: Installs `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and skill/command surfaces for coding agents
+🧭 **Parallel Agent Coordination**: Worktree-backed runs, path claims, and checkpoints for multi-agent work
 🤖 **AI-Powered**: Uses Claude AI for commit messages, branch names, and conflict resolution  
 📝 **PR Automation**: Auto-generated pull request titles and descriptions  
 📊 **Repository Status**: Enhanced repository status with platform detection  
@@ -18,6 +20,41 @@ GitPlus is a Model Context Protocol (MCP) server that brings AI-powered git auto
 🌐 **Multi-Platform**: Supports GitHub, GitLab, and local repositories
 
 ## Quick Start
+
+### Install Agent Instructions
+
+Use this first when you want coding agents to rely on GitPlus for repository work:
+
+```bash
+npx @neublink/gitplus init-agent --agent all
+```
+
+This writes managed GitPlus sections into agent-facing files:
+
+- `AGENTS.md` for Codex and agent-runner conventions
+- `CLAUDE.md` and `.claude/skills/gitplus/SKILL.md` for Claude
+- `GEMINI.md` and `.gemini/commands/git/ship.toml` for Gemini
+- `.agents/skills/gitplus/SKILL.md` for Codex-style skill discovery
+
+For one agent only:
+
+```bash
+npx @neublink/gitplus init-agent --agent codex
+npx @neublink/gitplus init-agent --agent claude
+npx @neublink/gitplus init-agent --agent gemini
+```
+
+### Agent Workflow
+
+```bash
+npx @neublink/gitplus start --agent codex --task "add billing tests"
+npx @neublink/gitplus status --verbose
+npx @neublink/gitplus claim src/billing tests/billing
+npx @neublink/gitplus checkpoint --summary "added billing edge-case tests" --test "npm test -- billing"
+npx @neublink/gitplus ship
+```
+
+For parallel agents, each agent should start its own GitPlus run, claim the files it owns, checkpoint before handoff, and use `gitplus ship` instead of raw `git commit` and `git push`.
 
 ### Install as MCP Server for Claude Code
 
@@ -105,10 +142,10 @@ Get comprehensive information about GitPlus MCP server capabilities and usage
 
 ## Architecture
 
-GitPlus follows a **simplified MCP-first architecture** designed around intelligent automation:
+GitPlus follows a **simplified MCP-first architecture** for Claude Code while exposing CLI-only lifecycle commands that help coding agents coordinate local repository work without expanding the MCP tool surface.
 
 ### Core Design Philosophy
-- **3 Essential Tools**: Reduced from 14+ CLI commands to 3 MCP tools that handle everything
+- **3 Essential MCP Tools**: Keep the MCP surface focused while the CLI handles optional local agent lifecycle tasks
 - **AI-Powered Intelligence**: Uses Claude AI for all decision-making (commit messages, branch names, conflict resolution)
 - **Complete Workflows**: Each tool provides complete functionality rather than partial operations
 - **Zero Configuration**: Works out-of-the-box with sensible defaults
@@ -117,7 +154,7 @@ GitPlus follows a **simplified MCP-first architecture** designed around intellig
 - **TypeScript**: Type-safe development with strict compilation
 - **MCP SDK**: Official Model Context Protocol SDK for Claude Code integration
 - **Zod**: Runtime type validation for inputs and outputs
-- **Node.js**: Cross-platform compatibility (Node 16+)
+- **Node.js**: Cross-platform compatibility (Node 18+)
 - **Conventional Commits**: Strict adherence to commit message standards
 
 ### Key Components
@@ -161,7 +198,7 @@ refactor(utils): extract validation logic   # Code restructuring
 
 ## Prerequisites
 
-- **Node.js 16+**: Required runtime environment
+- **Node.js 18+**: Required runtime environment
 - **Git**: For repository management
 - **Claude CLI**: Install and authenticate with `claude auth login`
   ```bash
@@ -352,5 +389,5 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-Made with ❤️ for the Claude Code community
+Made for coding agents that need safer git workflows
 <!-- Trigger merge decision re-analysis -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neublink/gitplus",
   "version": "1.3.2",
-  "description": "AI-powered Git automation MCP server for Claude Code",
+  "description": "Git workflow automation for coding agents and MCP clients",
   "main": "dist/index.js",
   "bin": {
     "gitplus": "dist/main.js",
@@ -35,6 +35,9 @@
   "keywords": [
     "mcp",
     "claude",
+    "codex",
+    "gemini",
+    "coding-agents",
     "git",
     "automation",
     "ai",

--- a/src/agent/installKit.test.ts
+++ b/src/agent/installKit.test.ts
@@ -38,7 +38,11 @@ describe('installAgentKit', () => {
     expect(countOccurrences(secondAgentsContent, '<!-- gitplus-agent-kit:start -->')).toBe(1);
     expect(secondSkillContent.startsWith('---\nname: gitplus')).toBe(true);
     expect(countOccurrences(secondSkillContent, '<!-- gitplus-agent-kit:start -->')).toBe(1);
+    expect(secondAgentsContent).toContain('GitPlus Agent Git Contract');
+    expect(secondAgentsContent).toContain('npx @neublink/gitplus init-agent --agent codex');
     expect(secondAgentsContent).toContain('npx @neublink/gitplus ship');
+    expect(secondAgentsContent).toContain('Parallel Agent Rules');
+    expect(secondAgentsContent).toContain('Keep each agent on its own GitPlus worktree and branch');
     expect(secondAgentsContent).toContain('Avoid raw `git commit`, `git push`, and manual pull request creation');
   });
 
@@ -89,6 +93,7 @@ describe('installAgentKit', () => {
     expect(geminiCommand).toContain('# gitplus-agent-kit:start');
     expect(geminiCommand).toContain('description = "Ship repository changes with GitPlus"');
     expect(geminiCommand).toContain('npx @neublink/gitplus start');
+    expect(geminiCommand).toContain('Parallel Agent Rules');
     expect(countOccurrences(geminiCommand, '# gitplus-agent-kit:start')).toBe(1);
   });
 });

--- a/src/agent/installKit.ts
+++ b/src/agent/installKit.ts
@@ -44,24 +44,18 @@ const AGENT_ORDER: AgentName[] = ['codex', 'claude', 'gemini'];
 
 export async function installAgentKit(options: InstallAgentKitOptions): Promise<InstallFileResult[]> {
   const agents = resolveAgents(options.agent);
-  const results: InstallFileResult[] = [];
+  const selectedSurfaces = getInstallSurfaces().filter(surface => agents.includes(surface.agent));
 
-  for (const surface of getInstallSurfaces()) {
-    if (!agents.includes(surface.agent)) {
-      continue;
-    }
-
+  return Promise.all(selectedSurfaces.map(async (surface): Promise<InstallFileResult> => {
     const absolutePath = join(options.repoPath, surface.relativePath);
     const status = await writeManagedBlock(absolutePath, surface.content, surface.markers, surface.preamble);
 
-    results.push({
+    return {
       agent: surface.agent,
       path: surface.relativePath,
       status,
-    });
-  }
-
-  return results;
+    };
+  }));
 }
 
 export async function writeManagedBlock(
@@ -184,15 +178,32 @@ function escapeRegExp(value: string): string {
 function sharedInstructions(agentLabel: string): string {
   const agentName = agentLabel.toLowerCase();
 
-  return `## GitPlus Git Operations
+  return `## GitPlus Agent Git Contract
 
-When working in this repository as ${agentLabel}, use GitPlus for repository operations:
+When working in this repository as ${agentLabel}, use GitPlus as the default interface for repository operations. The goal is to give coding agents the same safety rails Git gives humans: isolated work, visible ownership, reviewable checkpoints, and repeatable shipping.
+
+### Setup
+
+- If this repository does not already contain GitPlus instructions, run \`npx @neublink/gitplus init-agent --agent ${agentName}\` before starting agent work.
+
+### Work Lifecycle
 
 - Use \`npx @neublink/gitplus start --agent ${agentName} --task "<task>"\` before making changes so GitPlus can create an isolated worktree and run ledger.
 - Use \`npx @neublink/gitplus status --verbose\` instead of raw \`git status\` for change review, branch context, and current run context.
 - Use \`npx @neublink/gitplus claim <paths...>\` before editing files that may overlap with another agent's work.
 - Use \`npx @neublink/gitplus checkpoint --summary "<what changed>" --test "<validation command>"\` to save meaningful work-in-progress states.
 - Use \`npx @neublink/gitplus ship\` to create commits, push branches, and open pull requests.
+
+### Parallel Agent Rules
+
+- Claim files or directories before editing shared surfaces.
+- Keep each agent on its own GitPlus worktree and branch.
+- Do not edit another active agent's claimed paths unless the task explicitly requires coordination.
+- Checkpoint before switching tasks, handing off work, or attempting conflict-prone changes.
+- Include the exact tests, checks, or manual verification run in each checkpoint.
+
+### Recovery Rules
+
 - Avoid raw \`git commit\`, \`git push\`, and manual pull request creation except when recovering from a broken GitPlus operation.
 - If recovery requires raw git commands, explain why in your final response and return to GitPlus commands afterward.`;
 }
@@ -246,6 +257,12 @@ Run:
 3. npx @neublink/gitplus claim <paths...> before overlapping edits
 4. npx @neublink/gitplus checkpoint --summary "<what changed>" --test "<validation command>" when useful
 5. npx @neublink/gitplus ship
+
+Parallel Agent Rules:
+- Start one GitPlus run per agent.
+- Keep each agent on its own GitPlus worktree and branch.
+- Claim shared files or directories before editing them.
+- Checkpoint before handoff or conflict-prone changes.
 
 Avoid raw git commit, git push, and manual pull request creation except when recovering from a broken GitPlus operation. If recovery is required, explain why and return to GitPlus commands afterward.
 """`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import prompts from 'prompts';
+import { randomUUID } from 'crypto';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -100,6 +101,15 @@ function getPackageVersion(): string {
 }
 
 const program = new Command();
+const OPTIONAL_MODULE_CANDIDATES = new Set([
+  './agent/runtime',
+  './runtime/agent',
+  './runtime',
+  './agent/install-kit',
+  './agent/installKit',
+  './install-kit/agent',
+  './install-kit',
+]);
 
 // Helper to format output
 function output(message: string) {
@@ -114,6 +124,10 @@ function handleError(error: any) {
 
 function loadOptionalModule<T>(moduleCandidates: string[]): T | undefined {
   for (const modulePath of moduleCandidates) {
+    if (!OPTIONAL_MODULE_CANDIDATES.has(modulePath) || modulePath.includes('..')) {
+      throw new Error(`Unsupported optional module candidate: ${modulePath}`);
+    }
+
     try {
       const loaded = require(modulePath);
       return (loaded.default || loaded) as T;
@@ -184,15 +198,56 @@ function printResult(result: unknown) {
   }
 }
 
+function isInstallFileResults(result: unknown): result is Array<{ agent: string; path: string; status: string }> {
+  return Array.isArray(result) && result.every((entry) => (
+    entry &&
+    typeof entry === 'object' &&
+    typeof (entry as Record<string, unknown>)['agent'] === 'string' &&
+    typeof (entry as Record<string, unknown>)['path'] === 'string' &&
+    typeof (entry as Record<string, unknown>)['status'] === 'string'
+  ));
+}
+
+function printInstallResults(result: unknown) {
+  if (!isInstallFileResults(result)) {
+    printResult(result);
+    return;
+  }
+
+  output('\nInstalled agent surfaces:');
+  for (const entry of result) {
+    output(`  - ${entry.status}: ${entry.path} (${entry.agent})`);
+  }
+}
+
 function createRunId(agent: string): string {
-  const safeAgent = agent.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'agent';
-  return `${safeAgent}-${Date.now().toString(36)}`;
+  const safeAgent = createSlug(agent, 'agent', 48, /[^a-z0-9._-]+/g);
+  return `${safeAgent}-${randomUUID().slice(0, 8)}`;
 }
 
 function createBranchName(agent: string, task: string): string {
-  const safeAgent = agent.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'agent';
-  const safeTask = task.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'task';
-  return `gitplus/${safeAgent}/${safeTask}-${Date.now().toString(36)}`;
+  const safeAgent = createSlug(agent, 'agent', 48, /[^a-z0-9._-]+/g);
+  const safeTask = createSlug(task, 'task', 48, /[^a-z0-9]+/g);
+  return `gitplus/${safeAgent}/${safeTask}-${randomUUID().slice(0, 8)}`;
+}
+
+function createSlug(value: string, fallback: string, maxLength: number, unsafePattern: RegExp): string {
+  const slug = value
+    .toLowerCase()
+    .replace(unsafePattern, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, maxLength)
+    .replace(/^-+|-+$/g, '');
+
+  if (!slug) {
+    return fallback;
+  }
+
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(slug)) {
+    throw new Error(`Could not create a safe slug from input: ${value}`);
+  }
+
+  return slug;
 }
 
 function getRunId(run: unknown): string | undefined {
@@ -299,6 +354,28 @@ async function ensureGitRepository(gitClient: GitClient): Promise<boolean> {
     }
   }
   return true;
+}
+
+async function initializeAgentSupport(agent: AgentInitTarget) {
+  const gitClient = new GitClient();
+  await ensureGitRepository(gitClient);
+
+  const installKit = loadAgentInstallKit();
+  const initAgentRuntime = installKit?.initAgentRuntime || installKit?.init;
+  const installAgentKit = installKit?.installAgentKit;
+
+  if (!initAgentRuntime && !installAgentKit) {
+    printAgentRuntimeMissing('install kit');
+    return;
+  }
+
+  const cwd = gitClient.getWorkingDirectory();
+  const result = installAgentKit
+    ? await installAgentKit({ agent, repoPath: cwd })
+    : await initAgentRuntime!({ agent, cwd });
+
+  output(`✅ Initialized GitPlus agent support: ${agent}`);
+  printInstallResults(result);
 }
 
 program
@@ -579,25 +656,26 @@ program
   .requiredOption('--agent <agent>', 'Agent runtime to initialize (codex, claude, gemini, all)', parseInitAgent)
   .action(async (options) => {
     try {
-      const gitClient = new GitClient();
-      await ensureGitRepository(gitClient);
+      await initializeAgentSupport(options.agent);
+    } catch (error) {
+      handleError(error);
+    }
+  });
 
-      const installKit = loadAgentInstallKit();
-      const initAgentRuntime = installKit?.initAgentRuntime || installKit?.init;
-      const installAgentKit = installKit?.installAgentKit;
+program
+  .command('init-agent [agent]')
+  .description('Install GitPlus instructions for coding agents')
+  .option('--agent <agent>', 'Agent instructions to install (codex, claude, gemini, all)', parseInitAgent)
+  .action(async (agentArg: string | undefined, options) => {
+    try {
+      const positionalAgent = agentArg ? parseInitAgent(agentArg) : undefined;
+      const optionAgent = options.agent as AgentInitTarget | undefined;
 
-      if (!initAgentRuntime && !installAgentKit) {
-        printAgentRuntimeMissing('install kit');
-        return;
+      if (positionalAgent && optionAgent && positionalAgent !== optionAgent) {
+        throw new Error('Specify the agent once, either positionally or with --agent');
       }
 
-      const cwd = gitClient.getWorkingDirectory();
-      const result = installAgentKit
-        ? await installAgentKit({ agent: options.agent, repoPath: cwd })
-        : await initAgentRuntime!({ agent: options.agent, cwd });
-
-      output(`✅ Initialized GitPlus agent runtime: ${options.agent}`);
-      printResult(result);
+      await initializeAgentSupport(optionAgent || positionalAgent || 'all');
     } catch (error) {
       handleError(error);
     }


### PR DESCRIPTION
Summary:
- Add `gitplus init-agent` as the explicit onboarding command for Codex, Claude, Gemini, or all supported coding agents
- Expand generated agent instructions with setup, lifecycle, parallel-agent rules, and recovery guidance
- Update README/CLI positioning and package metadata for coding-agent workflows

Validation:
- npm test -- --runTestsByPath src/agent/installKit.test.ts
- npm run validate
- npm run build
- git diff --check
- Built CLI smoke test in a temporary git repo: `node dist/main.js init-agent --agent codex`