### PR TITLE
ci: opt workflows into Node 24 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, synchronize, reopened]
     # Run on all PR types - no path restrictions to ensure workflow and infrastructure changes are reviewed
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude-review:
     # Keep Claude optional while the repository token is rotated.
@@ -226,7 +230,7 @@ jobs:
 
       - name: Upload review analysis
         if: always()  # Upload even if review has issues
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: claude-review-analysis-${{ github.event.pull_request.number }}-${{ github.run_id }}
           path: /tmp/claude-review-${{ github.run_id }}-${{ github.run_attempt }}/claude-review-analysis.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-decision.yml
+++ b/.github/workflows/merge-decision.yml
@@ -17,6 +17,10 @@ on:
 # but does not execute user-controlled content. All checkouts use default refs,
 # and PR data is only used in safe contexts (API calls, conditional logic).
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write  # Required for merging PRs
   pull-requests: write

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ on:
         default: true
         type: boolean
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release-please-post.yml
+++ b/.github/workflows/release-please-post.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 # Prevent concurrent releases
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - 'v*'
       - 'gitplus-v*'
 
+env:
+  # Opt JavaScript actions into GitHub's Node 24 runtime before it becomes the default.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Opt every GitHub Actions workflow into the Node 24 JavaScript action runtime ahead of GitHub's 2026 deprecation timeline.

Also updates the Claude review artifact upload step from `actions/upload-artifact@v4` to the current official `actions/upload-artifact@v7` so that workflow no longer depends on the older Node 20 action runtime by default.

## Why

GitHub is warning that JavaScript actions running on Node 20 will be forced to Node 24 starting June 2, 2026 and Node 20 support will be removed September 16, 2026. This lets the repo test that runtime behavior now instead of finding out during the forced migration.

## Validation

- `npm run build`
- `npm run validate`
- `git diff --check`
- `actionlint -shellcheck= .github/workflows/*.yml`

Note: full `actionlint` still reports pre-existing shellcheck findings in existing inline scripts; those are unrelated to this workflow-runtime patch.
